### PR TITLE
chore(renovate): hold typescript on 6.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,10 @@
 {
-  "extends": ["config:recommended", ":disableDependencyDashboard"]
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7.0.0",
+      "description": "TypeScript 7 is the Go-native port and ships no stable programmatic compiler API (it lands in 7.1). typescript-eslint cannot parse with it, so type-aware linting breaks. Hold on 6.x until 7.1 and typescript-eslint support land."
+    }
+  ]
 }


### PR DESCRIPTION
## Why

Renovate keeps opening TypeScript 7 PRs (#205) that cannot be merged.

TypeScript 7 is the Go-native compiler port. Its npm package **no longer exposes the JS programmatic compiler API** — the main export is now just `lib/version.cjs`:

```
$ node -e "const ts=require('typescript'); console.log(ts.version, ts.createProgram, ts.Extension)"
7.0.2 undefined undefined
```

The compiler API is expected to return in **TypeScript 7.1** under the new `typescript/unstable/*` surface.

## Impact

`typescript-eslint` crashes on load, so type-aware linting breaks entirely:

```
TypeError: Cannot read properties of undefined (reading 'Cjs')
    at .../@typescript-eslint/typescript-estree/dist/create-program/shared.js:59:18
```

Every published `typescript-eslint` version — including the `8.65.1-alpha.*` canaries — caps its peer at `typescript >=4.8.4 <6.1.0`. Upstream [closed the TS 7 support request as not-planned](https://github.com/typescript-eslint/typescript-eslint/issues/10940) because the fix belongs on the TypeScript side.

Notably `tsc --noEmit` *does* pass under TS 7 (the CLI binary is fine) — it's only the API consumers that break, so the failure is easy to miss.

## Change

Pin `typescript` to `<7.0.0` in `renovate.json` so Renovate stops opening un-mergeable PRs. Lift the pin once 7.1 ships a stable API and `typescript-eslint` supports it.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)