### PR TITLE
chore(renovate): add tiered automerge configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,38 @@
 {
   "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "platformAutomerge": false,
   "packageRules": [
     {
       "matchPackageNames": ["typescript"],
       "allowedVersions": "<7.0.0",
       "description": "TypeScript 7 is the Go-native port and ships no stable programmatic compiler API (it lands in 7.1). typescript-eslint cannot parse with it, so type-aware linting breaks. Hold on 6.x until 7.1 and typescript-eslint support land."
+    },
+    {
+      "description": "Automerge GitHub Actions minor and patch updates. Scope is CI only, and a break fails loudly in the workflow run.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge devDependency minor and patch updates. These never reach the production bundle, and lint/type-check/test cover them.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge patch updates for runtime dependencies. Merging master deploys to production, so minors and majors stay manual.",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "Never automerge a major, regardless of dep type.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## What

Adds automerge rules to `renovate.json`, tiered by blast radius.

| Tier | Automerge |
|---|---|
| GitHub Actions minor/patch | ✅ CI-only scope, breaks fail loudly in the workflow |
| devDependencies minor/patch | ✅ eslint, vitest, playwright, prettier, types — never in the production bundle |
| Runtime dependency **patch** | ✅ covered by unit + e2e |
| Runtime dependency minor | ❌ manual |
| **Any major** | ❌ manual, via an explicit catch-all rule |

## Safety notes

**`minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"`** — no PR is opened until a release has been public for three days. Primary defense against a compromised npm publish, which matters given the size of the `@mui/*`, `@sentry/*` and `vite` dependency trees. `strict` is what makes the age check suppress PR creation rather than merely annotate it.

**`platformAutomerge: false`** — deliberate. `master` has no required status checks, so GitHub's auto-merge would merge the moment the PR opened, before CI finished. With this disabled, Renovate performs the merge itself and only once every check is green. (`allow_auto_merge` is also `false` on the repo.)

## Tradeoff being accepted

Merging `master` triggers `deploy.yml` → production at library.powercalc.nl. So an automerged patch bump deploys unattended. The e2e suite covers the grid, profile and statistics views, which is what makes patch-level defensible.

## Follow-up (not in this PR)

`master` is unprotected, so the "wait for green" guarantee currently lives in Renovate's logic rather than being enforced by GitHub. Adding branch protection with `unit-tests`, `e2e-tests` and `lint-and-type-check` as required checks would make it enforced. Left out because it changes the rules for direct pushes to `master` too.

## Verification

`npx renovate-config-validator renovate.json` → `INFO: Config validated successfully`

🤖 Generated with [Claude Code](https://claude.com/claude-code)