### PR TITLE
Mobile layout, profile page setup card and library recency

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -30,6 +30,10 @@ export const library = {
           sub_profile_count: 0,
           min_version: "1.16.0",
           compatible_integrations: ["hue"],
+          measure_settings: { SAMPLE_COUNT: 2, SLEEP_TIME: 3 },
+          measure_device_firmware: "ESPHome 2026.4.2",
+          discovery_by: "device",
+          linked_profile: "ikea/LED1836G9",
         },
         {
           id: "LCT010",

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -32,6 +32,18 @@ test("does not scroll sideways", async ({ page }) => {
   expect(scrollWidth).toBe(clientWidth);
 });
 
+test("keeps the profile within the phone viewport", async ({ page }) => {
+  await page.goto("/profiles/signify/LCA001");
+  await expect(page.getByRole("heading", { name: "Signify LCA001", level: 1 })).toBeVisible();
+
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+
+  expect(scrollWidth).toBe(clientWidth);
+});
+
 test("groups the profile attributes into sections", async ({ page }) => {
   await page.goto("/profiles/signify/LCA001");
 
@@ -43,6 +55,8 @@ test("groups the profile attributes into sections", async ({ page }) => {
 
   // The overline variant uppercases the headings in CSS.
   expect(headings).toEqual(["DEVICE", "POWER", "MEASUREMENT", "LIBRARY"]);
+  await expect(page.getByRole("heading", { name: "Device", level: 2 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Power", level: 2 })).toBeVisible();
 
   // Power figures belong to the Power section, not scattered through the list.
   await expect(groups.filter({ hasText: "Power" }).first().getByText("Max power")).toBeVisible();

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -32,21 +32,20 @@ test("does not scroll sideways", async ({ page }) => {
   expect(scrollWidth).toBe(clientWidth);
 });
 
-test("lists the profile attributes in their declared order", async ({ page }) => {
+test("groups the profile attributes into sections", async ({ page }) => {
   await page.goto("/profiles/signify/LCA001");
 
-  await expect(page.getByTestId("profile-attribute").first()).toBeVisible();
+  const groups = page.getByTestId("attribute-group");
+  // allInnerTexts does not auto-wait, so settle on the rendered page first.
+  await expect(groups.first()).toBeVisible();
 
-  const items = await page.getByTestId("profile-attribute").allInnerTexts();
-  const labels = items.map((text) => text.split("\n")[0]);
+  const headings = (await groups.allInnerTexts()).map((text) => text.split("\n")[0]);
 
-  expect(labels.slice(0, 5)).toEqual([
-    "Manufacturer",
-    "Model ID",
-    "Device type",
-    "Name",
-    "Description",
-  ]);
+  // The overline variant uppercases the headings in CSS.
+  expect(headings).toEqual(["DEVICE", "POWER", "MEASUREMENT", "LIBRARY"]);
+
+  // Power figures belong to the Power section, not scattered through the list.
+  await expect(groups.filter({ hasText: "Power" }).first().getByText("Max power")).toBeVisible();
 });
 
 test("keeps every profile tab reachable", async ({ page }) => {

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -46,6 +46,35 @@ test("links the filterable attributes back into the library", async ({ page }) =
   await expect(page.getByRole("gridcell", { name: "S31" })).toBeHidden();
 });
 
+test("offers both the GUI and YAML ways to use the profile", async ({ page }) => {
+  await page.goto("/profiles/signify/LCA001");
+
+  const setup = page.getByTestId("profile-setup");
+
+  // The GUI path is what the Powercalc docs recommend, so it leads.
+  await expect(
+    setup.getByRole("link", { name: /Home Assistant instance/ }),
+  ).toHaveAttribute("href", "https://my.home-assistant.io/redirect/config_flow_start/?domain=powercalc");
+
+  await setup.getByText("Or configure with YAML").click();
+
+  await expect(setup.getByText("manufacturer: signify")).toBeVisible();
+  await expect(setup.getByText("model: LCA001")).toBeVisible();
+});
+
+test("shows the fields the API publishes beyond the basics", async ({ page }) => {
+  await page.goto("/profiles/signify/LCA001");
+
+  await expect(page.getByText("SAMPLE_COUNT: 2, SLEEP_TIME: 3")).toBeVisible();
+  await expect(page.getByText("ESPHome 2026.4.2")).toBeVisible();
+  await expect(page.getByText("Automatic, by device")).toBeVisible();
+
+  // linked_profile is "<manufacturer>/<model>", which is exactly the profile route.
+  await page.getByRole("link", { name: "ikea/LED1836G9" }).click();
+
+  await expect(page).toHaveURL("/profiles/ikea/LED1836G9");
+});
+
 test("renders an error page for an unknown profile", async ({ page }) => {
   await page.goto("/profiles/signify/does-not-exist");
 

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -21,6 +21,19 @@ test("shows the usage stats loaded from the analytics endpoint", async ({ page }
 
   await expect(page.getByText("Used in 12.5% of installations")).toBeVisible();
   await expect(page.getByText(/480 out of 3840 total/)).toBeVisible();
+  await expect(
+    page.getByRole("progressbar", { name: "Profile usage across opted-in installations" }),
+  ).toHaveAttribute("aria-valuetext", "12.5%");
+  await expect(page.getByRole("button", { name: "About installation analytics" })).toBeVisible();
+});
+
+test("uses a readable device type and a clear empty usage state", async ({ page }) => {
+  await page.goto("/profiles/sonoff/S31");
+
+  await expect(page.getByText("Smart Switch", { exact: true })).toBeVisible();
+  await expect(page.getByText("No opted-in installations reported yet")).toBeVisible();
+  await expect(page.getByRole("progressbar")).toBeHidden();
+  await expect(page.getByText("Powercalc can discover this model automatically (by entity).")).toBeVisible();
 });
 
 test("navigates back to the library", async ({ page }) => {
@@ -46,15 +59,40 @@ test("links the filterable attributes back into the library", async ({ page }) =
   await expect(page.getByRole("gridcell", { name: "S31" })).toBeHidden();
 });
 
+test("top-aligns attribute labels and values in a consistent text column", async ({ page }) => {
+  await page.goto("/profiles/signify/LCA001");
+
+  const firstAttribute = page.getByTestId("profile-attribute").first();
+  const label = await firstAttribute.locator("dt span").boundingBox();
+  const value = await firstAttribute.locator("dd").boundingBox();
+
+  expect(label).not.toBeNull();
+  expect(value).not.toBeNull();
+  expect(Math.abs(label!.x - value!.x)).toBeLessThan(1);
+
+  const measurementSection = page
+    .getByRole("heading", { name: "Measurement", level: 2 })
+    .locator("xpath=..");
+  const valueTops = await measurementSection.locator("dd").evaluateAll((values) =>
+    values.slice(0, 4).map((item) => item.getBoundingClientRect().top),
+  );
+  expect(Math.max(...valueTops) - Math.min(...valueTops)).toBeLessThan(1);
+});
+
 test("offers both the GUI and YAML ways to use the profile", async ({ page }) => {
   await page.goto("/profiles/signify/LCA001");
 
   const setup = page.getByTestId("profile-setup");
 
+  await expect(setup.getByText(/Look for a discovery prompt/)).toBeVisible();
+  await setup.getByText("Set up manually instead").click();
+
   // The GUI path is what the Powercalc docs recommend, so it leads.
-  await expect(
-    setup.getByRole("link", { name: /Home Assistant instance/ }),
-  ).toHaveAttribute("href", "https://my.home-assistant.io/redirect/config_flow_start/?domain=powercalc");
+  await expect(setup.getByRole("link", { name: "Open in Home Assistant" })).toHaveAttribute(
+    "href",
+    "https://my.home-assistant.io/redirect/config_flow_start/?domain=powercalc",
+  );
+  await expect(setup.getByText("Virtual power (library)")).toBeVisible();
 
   await setup.getByText("Or configure with YAML").click();
 

--- a/e2e/whats-new.spec.ts
+++ b/e2e/whats-new.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "./fixtures/api";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("lists recently added profiles, newest first", async ({ page }) => {
+  await page.goto("/whats-new");
+
+  await expect(page.getByRole("heading", { name: "What's new" })).toBeVisible();
+  await expect(page).toHaveTitle("What's new · Powercalc profile library");
+});
+
+test("is reachable from the insights menu", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Insights" }).click();
+  await page.getByRole("menuitem", { name: "What's new" }).click();
+
+  await expect(page).toHaveURL("/whats-new");
+});

--- a/src/api/library.api.ts
+++ b/src/api/library.api.ts
@@ -24,6 +24,14 @@ export interface LibraryModel {
   sub_profile_count: number;
   min_version?: string;
   compatible_integrations?: string[];
+  /** Settings the measurement was taken with, e.g. sample count and tooling version. */
+  measure_settings?: Record<string, unknown>;
+  measure_device_firmware?: string;
+  /** "device" or "entity" when Powercalc can auto-discover this model. */
+  discovery_by?: string;
+  only_self_usage?: boolean;
+  /** "<manufacturer>/<model>" of the profile whose measurements this one reuses. */
+  linked_profile?: string;
 }
 
 export type LibraryJson = {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -168,6 +168,12 @@ export const Header = ({
 
                 <Divider sx={{my: 1}}/>
 
+                <MenuItem onClick={() => handleMenuItemClick('/whats-new')}>
+                  What&apos;s new
+                </MenuItem>
+
+                <Divider sx={{my: 1}}/>
+
                 <Typography variant="subtitle2" sx={{px: 2, py: 1, fontWeight: 'bold'}}>
                   Library stats
                 </Typography>

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -9,6 +9,7 @@ import FactoryIcon from "@mui/icons-material/Factory";
 import GithubIcon from "@mui/icons-material/GitHub";
 import HistoryIcon from "@mui/icons-material/History";
 import HomeIcon from "@mui/icons-material/Home";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import LayersIcon from "@mui/icons-material/Layers";
 import MediationIcon from "@mui/icons-material/Mediation";
 import MoreIcon from "@mui/icons-material/More";
@@ -33,8 +34,6 @@ import {
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
-import ListItem from "@mui/material/ListItem";
-import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 import React, {useState} from "react";
@@ -82,6 +81,13 @@ type ItemValueType = string | number | boolean | undefined | null | string[] | R
 
 /** Power figures are watts; the unit belongs next to the number, not only in the headline. */
 const watts = (value: ItemValueType) => `${String(value)} W`;
+const humanizeIdentifier = (value: string) =>
+  value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
 type AttributeGroup = "device" | "power" | "measurement" | "library";
 
 /** Section order and headings for the attributes tab. */
@@ -157,25 +163,6 @@ export const Profile = () => {
     );
   }
 
-  const TruncatedText = ({ text, maxLines = 2 }: { text: string, maxLines?: number }) => {
-    return (
-      <Tooltip title={text} arrow placement="top">
-        <Typography
-          variant="body2"
-          sx={{
-            display: '-webkit-box',
-            WebkitLineClamp: maxLines,
-            WebkitBoxOrient: 'vertical',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {text}
-        </Typography>
-      </Tooltip>
-    );
-  };
-
   const PropertyValue = ({property}: { property: PropertyItem }) => {
     if (property.renderFn && property.value != null) {
       return property.renderFn(property.value);
@@ -183,10 +170,6 @@ export const Profile = () => {
 
     if (property.label === "Aliases" && property.value) {
       return <AliasChips aliases={property.value as string[]} marginTop={1} wrap/>;
-    }
-
-    if (property.label === "Measure description" && property.value) {
-      return <TruncatedText text={property.value as string} />;
     }
 
     if (Array.isArray(property.value)) {
@@ -240,44 +223,66 @@ export const Profile = () => {
             return null;
           }
 
+          const headingId = `attribute-group-${key}`;
+
           return (
-              <Box key={key} data-testid="attribute-group">
+              <Box
+                  component="section"
+                  key={key}
+                  data-testid="attribute-group"
+                  aria-labelledby={headingId}
+              >
                 <Typography
+                    component="h2"
+                    id={headingId}
                     variant="overline"
                     color="text.secondary"
-                    sx={{fontWeight: 700, letterSpacing: ".08em"}}
+                    sx={{fontWeight: 700, letterSpacing: ".08em", m: 0}}
                 >
                   {label}
                 </Typography>
                 <Divider sx={{mb: 0.5}}/>
 
-                <Grid container spacing={1}>
+                <Grid component="dl" container spacing={1} sx={{m: 0}}>
                   {items.map((property) => (
                       <Grid
+                          component="div"
                           size={{xs: 12, sm: 6, md: 3}}
                           key={`${property.label}-${property.filterKey ?? ""}`}
+                          data-testid="profile-attribute"
+                          sx={{
+                            py: 1,
+                            minWidth: 0,
+                            display: "grid",
+                            gridTemplateColumns: "34px minmax(0, 1fr)",
+                            alignContent: "start",
+                          }}
                       >
-                        <ListItem
-                            data-testid="profile-attribute"
-                            disableGutters
-                            alignItems="flex-start"
-                            sx={{py: 1, px: 0}}
+                        <Typography
+                            component="dt"
+                            variant="caption"
+                            color="text.secondary"
+                            sx={{
+                              gridColumn: "1 / -1",
+                              display: "grid",
+                              gridTemplateColumns: "34px minmax(0, 1fr)",
+                              alignItems: "start",
+                            }}
                         >
-                          <ListItemAvatar sx={{minWidth: 34, mt: 0.25}}>
-                            <property.icon fontSize="small" sx={{color: "text.secondary"}}/>
-                          </ListItemAvatar>
-                          <ListItemText
-                              primary={property.label}
-                              secondary={<PropertyValue property={property}/>}
-                              // The values render chips and other block elements, which are not
-                              // valid inside the <p> the secondary slot uses by default.
-                              slotProps={{
-                                primary: {variant: "caption", color: "text.secondary"},
-                                secondary: {component: "div", color: "text.primary"},
-                              }}
-                              sx={{my: 0}}
-                          />
-                        </ListItem>
+                          <property.icon aria-hidden="true" fontSize="small"/>
+                          <Box component="span">{property.label}</Box>
+                        </Typography>
+                        <Box
+                            component="dd"
+                            sx={{
+                              gridColumn: 2,
+                              m: 0,
+                              color: "text.primary",
+                              overflowWrap: "anywhere",
+                            }}
+                        >
+                          <PropertyValue property={property}/>
+                        </Box>
                       </Grid>
                   ))}
                 </Grid>
@@ -398,7 +403,10 @@ export const Profile = () => {
             <Typography variant="caption" color="text.secondary" sx={{display: "block"}}>
               {label}
             </Typography>
-            <Typography variant="subtitle2" sx={{fontWeight: 700, lineHeight: 1.3}}>
+            <Typography
+                variant="subtitle2"
+                sx={{fontWeight: 700, lineHeight: 1.3, overflowWrap: "anywhere"}}
+            >
               {value}
             </Typography>
           </Box>
@@ -412,11 +420,12 @@ export const Profile = () => {
 
     if (!summaryData) return null;
 
+    const hasReportedUsage = profile.usageStats.installationCount > 0;
+
     return (
         <Card
             variant="outlined"
             sx={{
-              height: "100%",
               borderRadius: 2,
               bgcolor: "background.paper",
               backgroundImage: "var(--mui-overlays-6)",
@@ -430,26 +439,39 @@ export const Profile = () => {
               </Typography>
 
               <Typography variant="body2" sx={{fontWeight: 500}}>
-                Used in {profile.usageStats.percentage}% of installations
+                {hasReportedUsage
+                    ? `Used in ${profile.usageStats.percentage}% of installations`
+                    : "No opted-in installations reported yet"}
               </Typography>
 
-              <LinearProgress
-                  variant="determinate"
-                  value={profile.usageStats.percentage}
-                  sx={{
-                    height: 8,
-                    borderRadius: 999,
-                    bgcolor: "action.hover",
-                    "& .MuiLinearProgress-bar": {
+              {hasReportedUsage && (
+                <LinearProgress
+                    variant="determinate"
+                    value={profile.usageStats.percentage}
+                    aria-label="Profile usage across opted-in installations"
+                    aria-valuetext={`${profile.usageStats.percentage}%`}
+                    sx={{
+                      height: 8,
                       borderRadius: 999,
-                    },
-                  }}
-              />
+                      bgcolor: "action.hover",
+                      "& .MuiLinearProgress-bar": {
+                        borderRadius: 999,
+                      },
+                    }}
+                />
+              )}
 
               <Typography variant="body2" color="text.secondary">
                 {profile.usageStats.installationCount} out of {summaryData.sampled_installations} total{' '}
-                <Tooltip title="Active installations are all users who have opted in for analytics." arrow>
-                  <span style={{textDecoration: 'underline', textDecorationStyle: 'dotted'}}>installations</span>
+                installations
+                <Tooltip title="These are active installations whose users opted in to analytics." arrow>
+                  <IconButton
+                      size="small"
+                      aria-label="About installation analytics"
+                      sx={{p: 0.25, ml: 0.25, verticalAlign: "text-bottom"}}
+                  >
+                    <InfoOutlinedIcon sx={{fontSize: 16}}/>
+                  </IconButton>
                 </Tooltip>
               </Typography>
 
@@ -532,7 +554,7 @@ export const Profile = () => {
     },
     {
       label: "Discovery",
-      value: profile.discoveryBy ? `Automatic, by ${profile.discoveryBy}` : null,
+      value: `Automatic, by ${profile.discoveryBy ?? "entity"}`,
       icon: PermDeviceInformationIcon,
       group: "library",
     },
@@ -605,7 +627,7 @@ export const Profile = () => {
               </Button>
             </Box>
 
-            <Typography variant="h4" component="h1">
+            <Typography variant="h4" component="h1" sx={{overflowWrap: "anywhere"}}>
               {profile.manufacturer.fullName} {profile.modelId}
             </Typography>
             {profile.name && (
@@ -617,7 +639,7 @@ export const Profile = () => {
             <Stack direction="row" sx={{flexWrap: "wrap", gap: 1, mt: 2}}>
               <HeadlineFact
                   label="Device type"
-                  value={profile.deviceType}
+                  value={humanizeIdentifier(profile.deviceType)}
                   // Same per-device-type glyph the grid and the filter panel use.
                   icon={getDeviceTypeIcon(profile.deviceType) ?? TypeSpecimenIcon}
               />
@@ -626,7 +648,7 @@ export const Profile = () => {
               )}
               {profile.standbyPower != null && (
                 <HeadlineFact
-                    label="Standby"
+                    label="Standby power"
                     value={`${profile.standbyPower} W`}
                     icon={BedtimeIcon}
                 />

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -28,7 +28,6 @@ import {
   useMediaQuery,
   useTheme
 } from "@mui/material";
-import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Grid from "@mui/material/Grid";
 import Link from "@mui/material/Link";
@@ -44,6 +43,7 @@ import {useSummary} from "../hooks/useSummary";
 import type {FullPowerProfile} from "../types/PowerProfile";
 
 import {AliasChips} from "./AliasChips";
+import {ProfileSetup} from "./library/ProfileSetup";
 import {Plot} from "./Plot";
 
 interface TabPanelProps {
@@ -86,7 +86,10 @@ const distributeIntoColumns = <T,>(items: T[], columns: number): T[][] => {
   return result;
 };
 
-type ItemValueType = string | number | undefined | null | string[];
+type ItemValueType = string | number | boolean | undefined | null | string[] | Record<string, unknown>;
+
+/** Power figures are watts; the unit belongs next to the number, not only in the headline. */
+const watts = (value: ItemValueType) => `${String(value)} W`;
 interface PropertyItem {
   label: string;
   value: ItemValueType;
@@ -213,7 +216,12 @@ export const Profile = () => {
       );
     }
 
-    return property.value ?? null;
+    if (property.value == null || typeof property.value === "object") {
+      // Objects only render through a renderFn of their own; there is nothing sensible to print.
+      return null;
+    }
+
+    return String(property.value);
   };
 
   type AttributesTabProps = { chunkedProperties: PropertyItem[][] };
@@ -226,18 +234,23 @@ export const Profile = () => {
                     <ListItem
                         key={`${property.label}-${property.filterKey ?? ""}-${String(property.value)}`}
                         data-testid="profile-attribute"
+                        disableGutters
+                        alignItems="flex-start"
+                        sx={{py: 1, px: 0}}
                     >
-                      <ListItemAvatar>
-                        <Avatar>
-                          <property.icon/>
-                        </Avatar>
+                      <ListItemAvatar sx={{minWidth: 34, mt: 0.25}}>
+                        <property.icon fontSize="small" sx={{color: "text.secondary"}}/>
                       </ListItemAvatar>
                       <ListItemText
                           primary={property.label}
                           secondary={<PropertyValue property={property}/>}
                           // The values render chips and other block elements, which are not valid
                           // inside the <p> the secondary slot uses by default.
-                          slotProps={{secondary: {component: "div"}}}
+                          slotProps={{
+                            primary: {variant: "caption", color: "text.secondary"},
+                            secondary: {component: "div", color: "text.primary"},
+                          }}
+                          sx={{my: 0}}
                       />
                     </ListItem>
                 ))}
@@ -338,6 +351,20 @@ export const Profile = () => {
       </Grid>
   );
 
+  const HeadlineFact = ({label, value}: {label: string; value: string}) => (
+      <Paper
+          variant="outlined"
+          sx={{px: 1.5, py: 1, minWidth: 96, borderRadius: 2}}
+      >
+        <Typography variant="caption" color="text.secondary" sx={{display: "block"}}>
+          {label}
+        </Typography>
+        <Typography variant="subtitle2" sx={{fontWeight: 700}}>
+          {value}
+        </Typography>
+      </Paper>
+  );
+
   const ProfileMetrics = () => {
     // Fetch summary data (will be cached by React Query)
     const {data: summaryData} = useSummary();
@@ -383,15 +410,16 @@ export const Profile = () => {
                 <Tooltip title="Active installations are all users who have opted in for analytics." arrow>
                   <span style={{textDecoration: 'underline', textDecorationStyle: 'dotted'}}>installations</span>
                 </Tooltip>
-                {' '}
-                <Link
-                    href="https://docs.powercalc.nl/misc/analytics/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                  Learn how to opt-in
-                </Link>
               </Typography>
+
+              <Link
+                  variant="caption"
+                  href="https://docs.powercalc.nl/misc/analytics/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+              >
+                Learn how to opt-in
+              </Link>
             </Stack>
           </CardContent>
         </Card>
@@ -436,10 +464,48 @@ export const Profile = () => {
     {label: "Measure device", value: profile.measureDevice, icon: ElectricMeterIcon, filterKey: "measureDevice"},
     {label: "Measure method", value: profile.measureMethod, icon: ElectricMeterIcon, filterKey: "measureMethod"},
     {label: "Measure description", value: profile.measureDescription, icon: ElectricMeterIcon},
-    {label: "Max power", value: profile.maxPower, icon: BoltIcon},
-    {label: "Standby power", value: profile.standbyPower, icon: BoltIcon},
-    {label: "Standby power on", value: profile.standbyPowerOn, icon: BoltIcon},
+    {label: "Max power", value: profile.maxPower, icon: BoltIcon, renderFn: watts},
+    {label: "Standby power", value: profile.standbyPower, icon: BoltIcon, renderFn: watts},
+    {label: "Standby power on", value: profile.standbyPowerOn, icon: BoltIcon, renderFn: watts},
     {label: "Min version", value: profile.minVersion, icon: MoreIcon},
+    {
+      label: "Measure device firmware",
+      value: profile.measureDeviceFirmware,
+      icon: ElectricMeterIcon,
+    },
+    {
+      label: "Measure settings",
+      value: profile.measureSettings,
+      icon: ElectricMeterIcon,
+      renderFn: (value) => (
+        <Typography variant="body2" component="span">
+          {Object.entries(value as Record<string, unknown>)
+            .map(([key, entry]) => `${key}: ${String(entry)}`)
+            .join(", ")}
+        </Typography>
+      ),
+    },
+    {
+      label: "Discovery",
+      value: profile.discoveryBy ? `Automatic, by ${profile.discoveryBy}` : null,
+      icon: PermDeviceInformationIcon,
+    },
+    {
+      label: "Only self usage",
+      value: profile.onlySelfUsage ? "Yes" : null,
+      icon: BoltIcon,
+    },
+    {
+      label: "Linked profile",
+      value: profile.linkedProfile,
+      icon: MediationIcon,
+      // The value is "<manufacturer>/<model>", which is exactly the profile route.
+      renderFn: (value) => (
+        <Link component={RouterLink} to={`/profiles/${String(value)}`}>
+          {String(value)}
+        </Link>
+      ),
+    },
     {label: "Compatible integrations", value: profile.compatibleIntegrations, icon: MoreIcon},
   ];
 
@@ -471,7 +537,7 @@ export const Profile = () => {
 
   return (
       <>
-        <Grid container spacing={2}>
+        <Grid container spacing={2} sx={{mb: 3}}>
           <Grid size={{xs: 12, md: 8, lg: 9}}>
             <Box sx={{display: "flex", flexWrap: "wrap", mb: 2, gap: 2}}>
               <Button
@@ -502,11 +568,26 @@ export const Profile = () => {
                 {profile.name}
               </Typography>
             )}
+
+            <Stack direction="row" sx={{flexWrap: "wrap", gap: 1, mt: 2}}>
+              <HeadlineFact label="Device type" value={profile.deviceType}/>
+              {profile.maxPower != null && (
+                <HeadlineFact label="Max power" value={`${profile.maxPower} W`}/>
+              )}
+              {profile.standbyPower != null && (
+                <HeadlineFact label="Standby" value={`${profile.standbyPower} W`}/>
+              )}
+              {profile.subProfileCount > 0 && (
+                <HeadlineFact label="Sub profiles" value={String(profile.subProfileCount)}/>
+              )}
+            </Stack>
           </Grid>
           <Grid size={{xs: 12, md: 4, lg: 3}}>
             <ProfileMetrics/>
           </Grid>
         </Grid>
+
+        <ProfileSetup profile={profile}/>
 
         <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
           <Tabs

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,3 +1,4 @@
+import BedtimeIcon from "@mui/icons-material/Bedtime";
 import BoltIcon from "@mui/icons-material/Bolt";
 import CalculateIcon from "@mui/icons-material/Calculate";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
@@ -8,6 +9,7 @@ import FactoryIcon from "@mui/icons-material/Factory";
 import GithubIcon from "@mui/icons-material/GitHub";
 import HistoryIcon from "@mui/icons-material/History";
 import HomeIcon from "@mui/icons-material/Home";
+import LayersIcon from "@mui/icons-material/Layers";
 import MediationIcon from "@mui/icons-material/Mediation";
 import MoreIcon from "@mui/icons-material/More";
 import PaletteIcon from "@mui/icons-material/Palette";
@@ -23,7 +25,7 @@ import {
   ListItemButton,
   Collapse,
   IconButton,
-  Card, CardContent, Stack, LinearProgress,
+  Card, CardContent, Stack, LinearProgress, Divider,
   Tooltip,
   useMediaQuery,
   useTheme
@@ -43,6 +45,7 @@ import {useSummary} from "../hooks/useSummary";
 import type {FullPowerProfile} from "../types/PowerProfile";
 
 import {AliasChips} from "./AliasChips";
+import {getDeviceTypeIcon} from "./library/facetIcons";
 import {ProfileSetup} from "./library/ProfileSetup";
 import {Plot} from "./Plot";
 
@@ -75,25 +78,25 @@ const a11yProps = (index: number) => {
   };
 };
 
-/**
- * Deals the items across `columns` columns round-robin, so reading the rendered columns left to
- * right, row by row, yields the original order. That only holds while every column sits on one row,
- * which is why the count is chosen per breakpoint rather than fixed at 4.
- */
-const distributeIntoColumns = <T,>(items: T[], columns: number): T[][] => {
-  const result: T[][] = Array.from({length: columns}, () => []);
-  items.forEach((item, i) => result[i % columns].push(item));
-  return result;
-};
-
 type ItemValueType = string | number | boolean | undefined | null | string[] | Record<string, unknown>;
 
 /** Power figures are watts; the unit belongs next to the number, not only in the headline. */
 const watts = (value: ItemValueType) => `${String(value)} W`;
+type AttributeGroup = "device" | "power" | "measurement" | "library";
+
+/** Section order and headings for the attributes tab. */
+const ATTRIBUTE_GROUPS: {key: AttributeGroup; label: string}[] = [
+  {key: "device", label: "Device"},
+  {key: "power", label: "Power"},
+  {key: "measurement", label: "Measurement"},
+  {key: "library", label: "Library"},
+];
+
 interface PropertyItem {
   label: string;
   value: ItemValueType;
   icon: React.ElementType;
+  group: AttributeGroup;
   filterKey?: string;
   renderFn?: (value: ItemValueType) => React.ReactNode;
 }
@@ -224,40 +227,64 @@ export const Profile = () => {
     return String(property.value);
   };
 
-  type AttributesTabProps = { chunkedProperties: PropertyItem[][] };
-  const AttributesTab = ({chunkedProperties}: AttributesTabProps) => (
-      <Grid size={{xs: 12, md: 6}}>
-        <Grid container spacing={1}>
-          {chunkedProperties.map((chunk, columnIndex) => (
-              <Grid size={12 / chunkedProperties.length} key={columnIndex}>
-                {chunk.map((property) => (
-                    <ListItem
-                        key={`${property.label}-${property.filterKey ?? ""}-${String(property.value)}`}
-                        data-testid="profile-attribute"
-                        disableGutters
-                        alignItems="flex-start"
-                        sx={{py: 1, px: 0}}
-                    >
-                      <ListItemAvatar sx={{minWidth: 34, mt: 0.25}}>
-                        <property.icon fontSize="small" sx={{color: "text.secondary"}}/>
-                      </ListItemAvatar>
-                      <ListItemText
-                          primary={property.label}
-                          secondary={<PropertyValue property={property}/>}
-                          // The values render chips and other block elements, which are not valid
-                          // inside the <p> the secondary slot uses by default.
-                          slotProps={{
-                            primary: {variant: "caption", color: "text.secondary"},
-                            secondary: {component: "div", color: "text.primary"},
-                          }}
-                          sx={{my: 0}}
-                      />
-                    </ListItem>
-                ))}
-              </Grid>
-          ))}
-        </Grid>
-      </Grid>
+  type AttributesTabProps = { properties: PropertyItem[] };
+  /**
+   * Grouped into sections so related attributes sit together. Items flow left to right within a
+   * section, which is the natural Grid order — no round-robin dealing needed.
+   */
+  const AttributesTab = ({properties}: AttributesTabProps) => (
+      <Stack spacing={3}>
+        {ATTRIBUTE_GROUPS.map(({key, label}) => {
+          const items = properties.filter((property) => property.group === key);
+          if (items.length === 0) {
+            return null;
+          }
+
+          return (
+              <Box key={key} data-testid="attribute-group">
+                <Typography
+                    variant="overline"
+                    color="text.secondary"
+                    sx={{fontWeight: 700, letterSpacing: ".08em"}}
+                >
+                  {label}
+                </Typography>
+                <Divider sx={{mb: 0.5}}/>
+
+                <Grid container spacing={1}>
+                  {items.map((property) => (
+                      <Grid
+                          size={{xs: 12, sm: 6, md: 3}}
+                          key={`${property.label}-${property.filterKey ?? ""}`}
+                      >
+                        <ListItem
+                            data-testid="profile-attribute"
+                            disableGutters
+                            alignItems="flex-start"
+                            sx={{py: 1, px: 0}}
+                        >
+                          <ListItemAvatar sx={{minWidth: 34, mt: 0.25}}>
+                            <property.icon fontSize="small" sx={{color: "text.secondary"}}/>
+                          </ListItemAvatar>
+                          <ListItemText
+                              primary={property.label}
+                              secondary={<PropertyValue property={property}/>}
+                              // The values render chips and other block elements, which are not
+                              // valid inside the <p> the secondary slot uses by default.
+                              slotProps={{
+                                primary: {variant: "caption", color: "text.secondary"},
+                                secondary: {component: "div", color: "text.primary"},
+                              }}
+                              sx={{my: 0}}
+                          />
+                        </ListItem>
+                      </Grid>
+                  ))}
+                </Grid>
+              </Box>
+          );
+        })}
+      </Stack>
   );
 
   type JsonTabProps = { profile: FullPowerProfile };
@@ -351,17 +378,31 @@ export const Profile = () => {
       </Grid>
   );
 
-  const HeadlineFact = ({label, value}: {label: string; value: string}) => (
+  type HeadlineFactProps = {label: string; value: string; icon: React.ElementType};
+  const HeadlineFact = ({label, value, icon: Icon}: HeadlineFactProps) => (
       <Paper
           variant="outlined"
-          sx={{px: 1.5, py: 1, minWidth: 96, borderRadius: 2}}
+          // The same tinted surface the filter panel uses, so the app has one secondary surface
+          // rather than a new colour per component.
+          sx={(theme) => ({
+            px: 1.5,
+            py: 1,
+            borderRadius: 2,
+            backgroundColor: theme.palette.grey[100],
+            ...theme.applyStyles("dark", {backgroundColor: theme.palette.grey[900]}),
+          })}
       >
-        <Typography variant="caption" color="text.secondary" sx={{display: "block"}}>
-          {label}
-        </Typography>
-        <Typography variant="subtitle2" sx={{fontWeight: 700}}>
-          {value}
-        </Typography>
+        <Stack direction="row" sx={{alignItems: "center", gap: 1.25}}>
+          <Icon sx={{fontSize: 26, color: "text.secondary"}}/>
+          <Box sx={{minWidth: 0}}>
+            <Typography variant="caption" color="text.secondary" sx={{display: "block"}}>
+              {label}
+            </Typography>
+            <Typography variant="subtitle2" sx={{fontWeight: 700, lineHeight: 1.3}}>
+              {value}
+            </Typography>
+          </Box>
+        </Stack>
       </Paper>
   );
 
@@ -427,17 +468,18 @@ export const Profile = () => {
   };
 
   const properties: PropertyItem[] = [
-    {label: "Manufacturer", value: profile.manufacturer.fullName, icon: FactoryIcon, filterKey: "manufacturer"},
-    {label: "Model ID", value: profile.modelId, icon: PermDeviceInformationIcon},
-    {label: "Device type", value: profile.deviceType, icon: TypeSpecimenIcon, filterKey: "deviceType"},
-    {label: "Name", value: profile.name, icon: MoreIcon},
-    {label: "Description", value: profile.description, icon: MoreIcon},
-    {label: "Created", value: profile.createdAt.toLocaleString(), icon: HistoryIcon},
-    {label: "Updated", value: profile.updatedAt?.toLocaleString(), icon: HistoryIcon},
+    {label: "Manufacturer", value: profile.manufacturer.fullName, icon: FactoryIcon, group: "device", filterKey: "manufacturer"},
+    {label: "Model ID", value: profile.modelId, icon: PermDeviceInformationIcon, group: "device"},
+    {label: "Device type", value: profile.deviceType, icon: TypeSpecimenIcon, group: "device", filterKey: "deviceType"},
+    {label: "Name", value: profile.name, icon: MoreIcon, group: "device"},
+    {label: "Description", value: profile.description, icon: MoreIcon, group: "device"},
+    {label: "Created", value: profile.createdAt.toLocaleString(), icon: HistoryIcon, group: "library"},
+    {label: "Updated", value: profile.updatedAt?.toLocaleString(), icon: HistoryIcon, group: "library"},
     {
       label: "Author", 
       value: profile.author.name,
-      icon: PersonIcon, 
+      icon: PersonIcon,
+      group: "library",
       filterKey: "author",
       renderFn: () => (
         <Tooltip title="View this author's profiles" describeChild arrow placement="top">
@@ -457,26 +499,29 @@ export const Profile = () => {
       label: "Calculation strategy",
       value: profile.calculationStrategy,
       icon: CalculateIcon,
+      group: "measurement",
       filterKey: "calculationStrategy"
     },
-    {label: "Color modes", value: profile.colorModes, icon: PaletteIcon, filterKey: "colorMode"},
-    {label: "Aliases", value: profile.aliases, icon: MediationIcon},
-    {label: "Measure device", value: profile.measureDevice, icon: ElectricMeterIcon, filterKey: "measureDevice"},
-    {label: "Measure method", value: profile.measureMethod, icon: ElectricMeterIcon, filterKey: "measureMethod"},
-    {label: "Measure description", value: profile.measureDescription, icon: ElectricMeterIcon},
-    {label: "Max power", value: profile.maxPower, icon: BoltIcon, renderFn: watts},
-    {label: "Standby power", value: profile.standbyPower, icon: BoltIcon, renderFn: watts},
-    {label: "Standby power on", value: profile.standbyPowerOn, icon: BoltIcon, renderFn: watts},
-    {label: "Min version", value: profile.minVersion, icon: MoreIcon},
+    {label: "Color modes", value: profile.colorModes, icon: PaletteIcon, group: "device", filterKey: "colorMode"},
+    {label: "Aliases", value: profile.aliases, icon: MediationIcon, group: "device"},
+    {label: "Measure device", value: profile.measureDevice, icon: ElectricMeterIcon, group: "measurement", filterKey: "measureDevice"},
+    {label: "Measure method", value: profile.measureMethod, icon: ElectricMeterIcon, group: "measurement", filterKey: "measureMethod"},
+    {label: "Measure description", value: profile.measureDescription, icon: ElectricMeterIcon, group: "measurement"},
+    {label: "Max power", value: profile.maxPower, icon: BoltIcon, group: "power", renderFn: watts},
+    {label: "Standby power", value: profile.standbyPower, icon: BoltIcon, group: "power", renderFn: watts},
+    {label: "Standby power on", value: profile.standbyPowerOn, icon: BoltIcon, group: "power", renderFn: watts},
+    {label: "Min version", value: profile.minVersion, icon: MoreIcon, group: "library"},
     {
       label: "Measure device firmware",
       value: profile.measureDeviceFirmware,
       icon: ElectricMeterIcon,
+      group: "measurement",
     },
     {
       label: "Measure settings",
       value: profile.measureSettings,
       icon: ElectricMeterIcon,
+      group: "measurement",
       renderFn: (value) => (
         <Typography variant="body2" component="span">
           {Object.entries(value as Record<string, unknown>)
@@ -489,16 +534,19 @@ export const Profile = () => {
       label: "Discovery",
       value: profile.discoveryBy ? `Automatic, by ${profile.discoveryBy}` : null,
       icon: PermDeviceInformationIcon,
+      group: "library",
     },
     {
       label: "Only self usage",
       value: profile.onlySelfUsage ? "Yes" : null,
       icon: BoltIcon,
+      group: "library",
     },
     {
       label: "Linked profile",
       value: profile.linkedProfile,
       icon: MediationIcon,
+      group: "device",
       // The value is "<manufacturer>/<model>", which is exactly the profile route.
       renderFn: (value) => (
         <Link component={RouterLink} to={`/profiles/${String(value)}`}>
@@ -506,7 +554,7 @@ export const Profile = () => {
         </Link>
       ),
     },
-    {label: "Compatible integrations", value: profile.compatibleIntegrations, icon: MoreIcon},
+    {label: "Compatible integrations", value: profile.compatibleIntegrations, icon: MoreIcon, group: "library"},
   ];
 
   const filteredProperties = properties.filter(
@@ -517,9 +565,6 @@ export const Profile = () => {
   );
   const theme = useTheme();
   const isTabletUp = useMediaQuery(theme.breakpoints.up("sm"));
-  const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
-  const columnCount = isDesktop ? 4 : isTabletUp ? 2 : 1;
-  const chunkedProperties = distributeIntoColumns(filteredProperties, columnCount)
 
   const [value, setValue] = React.useState(0);
   const navigate = useNavigate();
@@ -529,7 +574,7 @@ export const Profile = () => {
   };
 
   const tabs = [
-    {label: "Attributes", render: <AttributesTab chunkedProperties={chunkedProperties}/>},
+    {label: "Attributes", render: <AttributesTab properties={filteredProperties}/>},
     {label: "JSON", render: <JsonTab profile={profile}/>},
     ...(profile.subProfiles.length > 0 ? [{label: "Sub Profiles", render: <SubProfilesTab profile={profile}/>}] : []),
     ...(profile.plots.length > 0 ? [{label: "Graphs", render: <PlotsTab profile={profile}/>}] : []),
@@ -570,15 +615,28 @@ export const Profile = () => {
             )}
 
             <Stack direction="row" sx={{flexWrap: "wrap", gap: 1, mt: 2}}>
-              <HeadlineFact label="Device type" value={profile.deviceType}/>
+              <HeadlineFact
+                  label="Device type"
+                  value={profile.deviceType}
+                  // Same per-device-type glyph the grid and the filter panel use.
+                  icon={getDeviceTypeIcon(profile.deviceType) ?? TypeSpecimenIcon}
+              />
               {profile.maxPower != null && (
-                <HeadlineFact label="Max power" value={`${profile.maxPower} W`}/>
+                <HeadlineFact label="Max power" value={`${profile.maxPower} W`} icon={BoltIcon}/>
               )}
               {profile.standbyPower != null && (
-                <HeadlineFact label="Standby" value={`${profile.standbyPower} W`}/>
+                <HeadlineFact
+                    label="Standby"
+                    value={`${profile.standbyPower} W`}
+                    icon={BedtimeIcon}
+                />
               )}
               {profile.subProfileCount > 0 && (
-                <HeadlineFact label="Sub profiles" value={String(profile.subProfileCount)}/>
+                <HeadlineFact
+                    label="Sub profiles"
+                    value={String(profile.subProfileCount)}
+                    icon={LayersIcon}
+                />
               )}
             </Stack>
           </Grid>

--- a/src/components/library/ActiveFilterChips.tsx
+++ b/src/components/library/ActiveFilterChips.tsx
@@ -84,15 +84,6 @@ export const ActiveFilterChips = ({
           }}
         />
       )}
-      {filters.updatedAfter && (
-        <Chip
-          size="small"
-          label={`Updated after: ${filters.updatedAfter}`}
-          onDelete={() => {
-            setDate("updatedAfter", undefined);
-          }}
-        />
-      )}
 
       {activeCount > 1 && (
         <Button size="small" color="inherit" onClick={clearAll}>

--- a/src/components/library/ColorModeIcons.tsx
+++ b/src/components/library/ColorModeIcons.tsx
@@ -2,7 +2,6 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import BrightnessIcon from "@mui/icons-material/Brightness6";
 import PaletteIcon from "@mui/icons-material/Palette";
 import ThermostatIcon from "@mui/icons-material/Thermostat";
-import TrendingDownIcon from "@mui/icons-material/TrendingDown";
 import { Stack, Tooltip } from "@mui/material";
 
 import { ColorMode } from "../../types/ColorMode";
@@ -12,7 +11,6 @@ const ICONS: Record<ColorMode, { title: string; Icon: typeof BrightnessIcon }> =
   [ColorMode.COLOR_TEMP]: { title: "Color Temperature", Icon: ThermostatIcon },
   [ColorMode.HS]: { title: "Hue/Saturation", Icon: PaletteIcon },
   [ColorMode.EFFECT]: { title: "Effect", Icon: AutoFixHighIcon },
-  [ColorMode.TAPERING]: { title: "Tapering", Icon: TrendingDownIcon },
 };
 
 export const ColorModeIcons = ({ colorModes }: { colorModes: ColorMode[] }) => {

--- a/src/components/library/FilterPanel.tsx
+++ b/src/components/library/FilterPanel.tsx
@@ -176,7 +176,7 @@ export const FilterPanel = ({
         );
       })}
 
-      <SectionHeading icon={SECTION_ICONS.dates}>Dates</SectionHeading>
+      <SectionHeading icon={SECTION_ICONS.dates}>Added</SectionHeading>
       <Stack sx={{ gap: 1.5, mt: 1, pb: 1 }}>
         <TextField
           size="small"
@@ -185,16 +185,6 @@ export const FilterPanel = ({
           value={filters.createdAfter ?? ""}
           onChange={(event) => {
             setDate("createdAfter", event.target.value);
-          }}
-          slotProps={{ inputLabel: { shrink: true } }}
-        />
-        <TextField
-          size="small"
-          type="date"
-          label="Updated after"
-          value={filters.updatedAfter ?? ""}
-          onChange={(event) => {
-            setDate("updatedAfter", event.target.value);
           }}
           slotProps={{ inputLabel: { shrink: true } }}
         />

--- a/src/components/library/LibraryCardList.tsx
+++ b/src/components/library/LibraryCardList.tsx
@@ -12,10 +12,12 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import type { PowerProfile } from "../../types/PowerProfile";
+import { isRecentlyAdded } from "../../utils/recency";
 import { AliasChips } from "../AliasChips";
 
 import { DeviceTypeIcon } from "./facetIcons";
 import { profileRowId } from "./LibraryDataGrid";
+import { NewBadge } from "./NewBadge";
 
 const PAGE_SIZE = 25;
 
@@ -73,6 +75,7 @@ export const LibraryCardList = ({ rows }: LibraryCardListProps) => {
                   <Typography variant="subtitle2" sx={{ fontWeight: 700 }} noWrap>
                     {profile.modelId}
                   </Typography>
+                  {isRecentlyAdded(profile) && <NewBadge />}
                 </Stack>
 
                 <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>

--- a/src/components/library/LibraryDataGrid.tsx
+++ b/src/components/library/LibraryDataGrid.tsx
@@ -1,4 +1,4 @@
-import { Box, Link } from "@mui/material";
+import { Box, Link, Stack } from "@mui/material";
 import type {
   GridColDef,
   GridColumnVisibilityModel,
@@ -12,10 +12,12 @@ import { Link as RouterLink, useNavigate } from "react-router-dom";
 
 import type { ColorMode } from "../../types/ColorMode";
 import type { Author, PowerProfile } from "../../types/PowerProfile";
+import { isRecentlyAdded } from "../../utils/recency";
 import { AliasChips } from "../AliasChips";
 
 import { ColorModeIcons } from "./ColorModeIcons";
 import { DeviceTypeIcon } from "./facetIcons";
+import { NewBadge } from "./NewBadge";
 
 const COLUMN_VISIBILITY_STORAGE_KEY = "libraryGridColumnVisibility";
 
@@ -60,6 +62,12 @@ const columns: GridColDef<PowerProfile>[] = [
     headerName: "Model",
     flex: 1,
     minWidth: 140,
+    renderCell: ({ value, row }: GridRenderCellParams<PowerProfile, string>) => (
+      <Stack direction="row" sx={{ alignItems: "center", gap: 1, height: "100%" }}>
+        <span>{value}</span>
+        {isRecentlyAdded(row) && <NewBadge />}
+      </Stack>
+    ),
   },
   {
     field: "name",

--- a/src/components/library/NewBadge.tsx
+++ b/src/components/library/NewBadge.tsx
@@ -1,0 +1,16 @@
+import { Chip, Tooltip } from "@mui/material";
+
+import { NEW_PROFILE_DAYS } from "../../utils/recency";
+
+/** Marks a profile added within the last `NEW_PROFILE_DAYS` days. */
+export const NewBadge = () => (
+  <Tooltip title={`Added in the last ${NEW_PROFILE_DAYS} days`} describeChild>
+    <Chip
+      label="New"
+      size="small"
+      color="secondary"
+      variant="outlined"
+      sx={{ height: 18, fontSize: "0.6875rem" }}
+    />
+  </Tooltip>
+);

--- a/src/components/library/ProfileSetup.test.ts
+++ b/src/components/library/ProfileSetup.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSensorYaml } from "./ProfileSetup";
+
+describe("buildSensorYaml", () => {
+  it("builds the library sensor snippet", () => {
+    expect(
+      buildSensorYaml({
+        manufacturerDir: "signify",
+        modelId: "LCT010",
+        entityId: "light.my_light",
+      }),
+    ).toBe(
+      [
+        "powercalc:",
+        "  sensors:",
+        "    - entity_id: light.my_light",
+        "      manufacturer: signify",
+        "      model: LCT010",
+      ].join("\n"),
+    );
+  });
+
+  it("appends a sub profile to the model with a slash", () => {
+    const yaml = buildSensorYaml({
+      manufacturerDir: "lifx",
+      modelId: "LIFX Z",
+      subProfile: "length_9",
+      entityId: "light.my_light",
+    });
+
+    expect(yaml).toContain("model: LIFX Z/length_9");
+  });
+
+  it("uses the manufacturer directory name, not its display name", () => {
+    const yaml = buildSensorYaml({
+      manufacturerDir: "tp-link",
+      modelId: "L530",
+      entityId: "light.x",
+    });
+
+    expect(yaml).toContain("manufacturer: tp-link");
+  });
+});

--- a/src/components/library/ProfileSetup.tsx
+++ b/src/components/library/ProfileSetup.tsx
@@ -25,8 +25,6 @@ import type { FullPowerProfile } from "../../types/PowerProfile";
 export const MY_HA_CONFIG_FLOW_URL =
   "https://my.home-assistant.io/redirect/config_flow_start/?domain=powercalc";
 
-const MY_HA_BADGE_URL = "https://my.home-assistant.io/badges/config_flow_start.svg";
-
 /**
  * Builds the YAML a Home Assistant user pastes into configuration.yaml.
  * Sub-profiles are appended to the model with a slash, per the Powercalc docs.
@@ -61,8 +59,7 @@ export type ProfileSetupProps = {
 export const ProfileSetup = ({ profile }: ProfileSetupProps) => {
   const [subProfile, setSubProfile] = useState("");
   const [copied, setCopied] = useState(false);
-  // The badge is served by my.home-assistant.io; fall back to a plain button if it cannot load.
-  const [badgeFailed, setBadgeFailed] = useState(false);
+  const discoveryBy = profile.discoveryBy ?? "entity";
 
   const yaml = buildSensorYaml({
     manufacturerDir: profile.manufacturer.dirName,
@@ -83,67 +80,45 @@ export const ProfileSetup = ({ profile }: ProfileSetupProps) => {
     }
   };
 
-  return (
-    <Paper variant="outlined" sx={{ p: 2, mb: 3 }} data-testid="profile-setup">
-      <Typography variant="h6" sx={{ fontSize: "1rem", fontWeight: 700, mb: 1.5 }}>
-        Use this profile
-      </Typography>
+  const manualSetup = (
+    <>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        sx={{ alignItems: { sm: "center" }, gap: 2 }}
+      >
+        <Box sx={{ flexGrow: 1 }}>
+          <Typography component="h3" variant="subtitle2" sx={{ fontWeight: 700 }}>
+            Through the interface{" "}
+            <Typography component="span" variant="body2" color="text.secondary">
+              (recommended)
+            </Typography>
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            Start the Powercalc config flow, choose <strong>Virtual power (library)</strong>, and
+            pick <strong>{profile.manufacturer.fullName}</strong> →{" "}
+            <strong>{profile.modelId}</strong>.
+          </Typography>
+        </Box>
 
-      {profile.discoveryBy && (
-        <Alert severity="success" variant="outlined" sx={{ mb: 2 }}>
-          Powercalc discovers this model automatically (by {profile.discoveryBy}) — it should appear
-          in Home Assistant without any setup.{" "}
-          <Link href="https://docs.powercalc.nl/library/discovery/" target="_blank" rel="noopener">
-            About discovery
-          </Link>
-        </Alert>
-      )}
-
-      <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-        Through the interface{" "}
-        <Typography component="span" variant="body2" color="text.secondary">
-          (recommended)
-        </Typography>
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 1.5 }}>
-        Start the Powercalc config flow, choose <strong>Virtual power sensor</strong>, then{" "}
-        <strong>Library</strong>, and pick <strong>{profile.manufacturer.fullName}</strong> →{" "}
-        <strong>{profile.modelId}</strong>.
-      </Typography>
-
-      <Box sx={{ mb: 1 }}>
-        {badgeFailed ? (
-          <Button
-            variant="contained"
-            startIcon={<HomeIcon />}
-            href={MY_HA_CONFIG_FLOW_URL}
-            target="_blank"
-            rel="noopener"
-          >
-            Open in my Home Assistant
-          </Button>
-        ) : (
-          <Link href={MY_HA_CONFIG_FLOW_URL} target="_blank" rel="noopener">
-            <Box
-              component="img"
-              src={MY_HA_BADGE_URL}
-              alt="Open your Home Assistant instance and start setting up a new integration."
-              onError={() => {
-                setBadgeFailed(true);
-              }}
-              sx={{ height: 30, display: "block" }}
-            />
-          </Link>
-        )}
-      </Box>
+        <Button
+          variant="contained"
+          startIcon={<HomeIcon />}
+          href={MY_HA_CONFIG_FLOW_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{ flexShrink: 0, alignSelf: { xs: "flex-start", sm: "center" } }}
+        >
+          Open in Home Assistant
+        </Button>
+      </Stack>
 
       <Accordion
         disableGutters
         elevation={0}
         sx={{ mt: 1, backgroundColor: "transparent", "&:before": { display: "none" } }}
       >
-        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 0, minHeight: 0 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 0 }}>
+          <Typography component="h3" variant="subtitle2" sx={{ fontWeight: 700 }}>
             Or configure with YAML
           </Typography>
         </AccordionSummary>
@@ -207,15 +182,48 @@ export const ProfileSetup = ({ profile }: ProfileSetupProps) => {
         </AccordionDetails>
       </Accordion>
 
-      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1.5 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1 }}>
         <Link
           href="https://docs.powercalc.nl/sensor-types/virtual-power-library/"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           Library sensor documentation
         </Link>
       </Typography>
+    </>
+  );
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 3 }} data-testid="profile-setup">
+      <Typography component="h2" variant="h6" sx={{ fontSize: "1rem", fontWeight: 700, mb: 1 }}>
+        Use this profile
+      </Typography>
+
+      <Alert severity="success" variant="outlined">
+        Powercalc can discover this model automatically (by {discoveryBy}). Look for a discovery
+        prompt in Home Assistant and accept it to create the sensors.{" "}
+        <Link
+          href="https://docs.powercalc.nl/library/discovery/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          About discovery
+        </Link>
+      </Alert>
+
+      <Accordion
+        disableGutters
+        elevation={0}
+        sx={{ mt: 1, backgroundColor: "transparent", "&:before": { display: "none" } }}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 0 }}>
+          <Typography component="h3" variant="subtitle2" sx={{ fontWeight: 700 }}>
+            Set up manually instead
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ px: 0, pt: 0 }}>{manualSetup}</AccordionDetails>
+      </Accordion>
     </Paper>
   );
 };

--- a/src/components/library/ProfileSetup.tsx
+++ b/src/components/library/ProfileSetup.tsx
@@ -1,0 +1,221 @@
+import CheckIcon from "@mui/icons-material/Check";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HomeIcon from "@mui/icons-material/Home";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Link,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useState } from "react";
+
+import type { FullPowerProfile } from "../../types/PowerProfile";
+
+/** Opens the Powercalc config flow in the reader's own Home Assistant instance. */
+export const MY_HA_CONFIG_FLOW_URL =
+  "https://my.home-assistant.io/redirect/config_flow_start/?domain=powercalc";
+
+const MY_HA_BADGE_URL = "https://my.home-assistant.io/badges/config_flow_start.svg";
+
+/**
+ * Builds the YAML a Home Assistant user pastes into configuration.yaml.
+ * Sub-profiles are appended to the model with a slash, per the Powercalc docs.
+ */
+export const buildSensorYaml = ({
+  manufacturerDir,
+  modelId,
+  subProfile,
+  entityId,
+}: {
+  manufacturerDir: string;
+  modelId: string;
+  subProfile?: string;
+  entityId: string;
+}): string => {
+  const model = subProfile ? `${modelId}/${subProfile}` : modelId;
+  return [
+    "powercalc:",
+    "  sensors:",
+    `    - entity_id: ${entityId}`,
+    `      manufacturer: ${manufacturerDir}`,
+    `      model: ${model}`,
+  ].join("\n");
+};
+
+const ENTITY_PLACEHOLDER = "light.my_light";
+
+export type ProfileSetupProps = {
+  profile: FullPowerProfile;
+};
+
+export const ProfileSetup = ({ profile }: ProfileSetupProps) => {
+  const [subProfile, setSubProfile] = useState("");
+  const [copied, setCopied] = useState(false);
+  // The badge is served by my.home-assistant.io; fall back to a plain button if it cannot load.
+  const [badgeFailed, setBadgeFailed] = useState(false);
+
+  const yaml = buildSensorYaml({
+    manufacturerDir: profile.manufacturer.dirName,
+    modelId: profile.modelId,
+    subProfile: subProfile || undefined,
+    entityId: ENTITY_PLACEHOLDER,
+  });
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(yaml);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch {
+      // Clipboard access can be denied; the snippet is selectable either way.
+    }
+  };
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 3 }} data-testid="profile-setup">
+      <Typography variant="h6" sx={{ fontSize: "1rem", fontWeight: 700, mb: 1.5 }}>
+        Use this profile
+      </Typography>
+
+      {profile.discoveryBy && (
+        <Alert severity="success" variant="outlined" sx={{ mb: 2 }}>
+          Powercalc discovers this model automatically (by {profile.discoveryBy}) — it should appear
+          in Home Assistant without any setup.{" "}
+          <Link href="https://docs.powercalc.nl/library/discovery/" target="_blank" rel="noopener">
+            About discovery
+          </Link>
+        </Alert>
+      )}
+
+      <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+        Through the interface{" "}
+        <Typography component="span" variant="body2" color="text.secondary">
+          (recommended)
+        </Typography>
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, mb: 1.5 }}>
+        Start the Powercalc config flow, choose <strong>Virtual power sensor</strong>, then{" "}
+        <strong>Library</strong>, and pick <strong>{profile.manufacturer.fullName}</strong> →{" "}
+        <strong>{profile.modelId}</strong>.
+      </Typography>
+
+      <Box sx={{ mb: 1 }}>
+        {badgeFailed ? (
+          <Button
+            variant="contained"
+            startIcon={<HomeIcon />}
+            href={MY_HA_CONFIG_FLOW_URL}
+            target="_blank"
+            rel="noopener"
+          >
+            Open in my Home Assistant
+          </Button>
+        ) : (
+          <Link href={MY_HA_CONFIG_FLOW_URL} target="_blank" rel="noopener">
+            <Box
+              component="img"
+              src={MY_HA_BADGE_URL}
+              alt="Open your Home Assistant instance and start setting up a new integration."
+              onError={() => {
+                setBadgeFailed(true);
+              }}
+              sx={{ height: 30, display: "block" }}
+            />
+          </Link>
+        )}
+      </Box>
+
+      <Accordion
+        disableGutters
+        elevation={0}
+        sx={{ mt: 1, backgroundColor: "transparent", "&:before": { display: "none" } }}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 0, minHeight: 0 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+            Or configure with YAML
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ px: 0, pt: 0 }}>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            sx={{ alignItems: { sm: "center" }, gap: 1, mb: 1.5 }}
+          >
+            <Typography variant="body2" color="text.secondary" sx={{ flexGrow: 1 }}>
+              Add this to your <code>configuration.yaml</code>, replacing{" "}
+              <code>{ENTITY_PLACEHOLDER}</code> with your own entity.
+            </Typography>
+
+            {profile.subProfiles.length > 0 && (
+              <TextField
+                select
+                size="small"
+                label="Sub profile"
+                value={subProfile}
+                onChange={(event) => {
+                  setSubProfile(event.target.value);
+                }}
+                sx={{ minWidth: 180 }}
+              >
+                <MenuItem value="">None</MenuItem>
+                {profile.subProfiles.map((entry) => (
+                  <MenuItem key={entry.name} value={entry.name}>
+                    {entry.name}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+
+            <Tooltip title={copied ? "Copied" : "Copy YAML"}>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={copied ? <CheckIcon /> : <ContentCopyIcon />}
+                onClick={() => {
+                  void handleCopy();
+                }}
+              >
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </Tooltip>
+          </Stack>
+
+          <Box
+            component="pre"
+            sx={{
+              m: 0,
+              p: 1.5,
+              borderRadius: 1,
+              overflowX: "auto",
+              fontSize: "0.8125rem",
+              backgroundColor: (theme) => theme.palette.action.hover,
+            }}
+          >
+            <code>{yaml}</code>
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 1.5 }}>
+        <Link
+          href="https://docs.powercalc.nl/sensor-types/virtual-power-library/"
+          target="_blank"
+          rel="noopener"
+        >
+          Library sensor documentation
+        </Link>
+      </Typography>
+    </Paper>
+  );
+};

--- a/src/components/library/facetIcons.tsx
+++ b/src/components/library/facetIcons.tsx
@@ -73,12 +73,16 @@ const DEVICE_TYPE_ICONS: Partial<Record<DeviceType, SvgIconComponent>> = {
   [DeviceType.VACUUM_ROBOT]: CleaningServicesIcon,
 };
 
+/** The icon for a device type, or undefined for one this map has not caught up with yet. */
+export const getDeviceTypeIcon = (deviceType: string): SvgIconComponent | undefined =>
+  DEVICE_TYPE_ICONS[deviceType as DeviceType];
+
 /**
  * The device type as its icon, with the raw value one hover away. Falls back to plain text for a
  * type the API added before this map caught up.
  */
 export const DeviceTypeIcon = ({ deviceType }: { deviceType: string }) => {
-  const Icon = DEVICE_TYPE_ICONS[deviceType as DeviceType];
+  const Icon = getDeviceTypeIcon(deviceType);
   return (
     // A bare icon sits on the text baseline and rides high in a grid cell, so it needs its own
     // full-height flex box to centre against the row.

--- a/src/components/statistics/WhatsNew.tsx
+++ b/src/components/statistics/WhatsNew.tsx
@@ -1,0 +1,112 @@
+import { Box, Divider, List, ListItemButton, Stack, Typography } from "@mui/material";
+import { useMemo } from "react";
+import { Link as RouterLink } from "react-router-dom";
+
+import { useLibrary } from "../../context/LibraryContext";
+import { usePageMeta } from "../../hooks/usePageMeta";
+import type { PowerProfile } from "../../types/PowerProfile";
+import { NEW_PROFILE_DAYS, isRecentlyAdded, recentlyAdded } from "../../utils/recency";
+import { AliasChips } from "../AliasChips";
+import { DeviceTypeIcon } from "../library/facetIcons";
+import { NewBadge } from "../library/NewBadge";
+
+const WINDOW_DAYS = 90;
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+
+const groupByDay = (profiles: PowerProfile[]) => {
+  const groups = new Map<string, PowerProfile[]>();
+  for (const profile of profiles) {
+    const key = formatDate(profile.createdAt);
+    groups.set(key, [...(groups.get(key) ?? []), profile]);
+  }
+  return [...groups.entries()];
+};
+
+/**
+ * Driven by `createdAt`. `updatedAt` looks tempting but is meaningless here: nearly every profile
+ * in the library carries a recent update timestamp from bulk re-imports.
+ */
+export const WhatsNew = () => {
+  const { powerProfiles } = useLibrary();
+
+  usePageMeta({
+    title: "What's new",
+    description: `Power profiles added to the Powercalc library in the last ${WINDOW_DAYS} days.`,
+  });
+
+  const recent = useMemo(
+    () => recentlyAdded(powerProfiles, WINDOW_DAYS),
+    [powerProfiles],
+  );
+  const groups = useMemo(() => groupByDay(recent), [recent]);
+
+  return (
+    <Box>
+      <Typography variant="h4" component="h1" gutterBottom>
+        What&apos;s new
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        {recent.length} power {recent.length === 1 ? "profile" : "profiles"} added in the last{" "}
+        {WINDOW_DAYS} days. Anything from the last {NEW_PROFILE_DAYS} days is flagged as new across
+        the library.
+      </Typography>
+
+      {recent.length === 0 && (
+        <Typography color="text.secondary">
+          No profiles have been added in this window.
+        </Typography>
+      )}
+
+      {groups.map(([day, profiles]) => (
+        <Box key={day} sx={{ mb: 3 }} data-testid="whats-new-day">
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+            {day}
+          </Typography>
+          <List disablePadding>
+            {profiles.map((profile) => (
+              <Box key={`${profile.manufacturer.dirName}/${profile.modelId}`}>
+                <ListItemButton
+                  component={RouterLink}
+                  to={`/profiles/${profile.manufacturer.dirName}/${profile.modelId}`}
+                  sx={{ alignItems: "flex-start", gap: 1.5, py: 1.5 }}
+                >
+                  <Box sx={{ width: 24, flexShrink: 0, mt: 0.25 }}>
+                    <DeviceTypeIcon deviceType={profile.deviceType} />
+                  </Box>
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Stack direction="row" sx={{ alignItems: "center", gap: 0.75, minWidth: 0 }}>
+                      <Typography variant="body2" color="text.secondary" noWrap>
+                        {profile.manufacturer.fullName}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        ·
+                      </Typography>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 700 }} noWrap>
+                        {profile.modelId}
+                      </Typography>
+                      {isRecentlyAdded(profile) && <NewBadge />}
+                    </Stack>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                      {profile.name}
+                    </Typography>
+                    {profile.aliases.length > 0 && (
+                      <Box sx={{ mt: 0.75 }}>
+                        <AliasChips aliases={profile.aliases} maxVisible={2} />
+                      </Box>
+                    )}
+                    <Typography variant="caption" color="text.secondary">
+                      by {profile.author.name}
+                    </Typography>
+                  </Box>
+                </ListItemButton>
+                <Divider component="li" />
+              </Box>
+            ))}
+          </List>
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/hooks/useLibraryFilters.test.tsx
+++ b/src/hooks/useLibraryFilters.test.tsx
@@ -40,11 +40,8 @@ describe("parseFilters", () => {
     expect(parse("standbyPower=5-1").ranges.standbyPower).toBeUndefined();
   });
 
-  it("parses the date bounds", () => {
-    const filters = parse("createdAfter=2025-01-01&updatedAfter=2025-02-01");
-
-    expect(filters.createdAfter).toBe("2025-01-01");
-    expect(filters.updatedAfter).toBe("2025-02-01");
+  it("parses the created-after bound", () => {
+    expect(parse("createdAfter=2025-01-01").createdAfter).toBe("2025-01-01");
   });
 });
 

--- a/src/hooks/useLibraryFilters.ts
+++ b/src/hooks/useLibraryFilters.ts
@@ -7,7 +7,6 @@ import {
   FACET_KEYS,
   RANGE_KEYS,
   SEARCH_PARAM,
-  UPDATED_AFTER_PARAM,
   createEmptyFilters,
 } from "../types/LibraryFilters";
 
@@ -43,7 +42,6 @@ export const parseFilters = (searchParams: URLSearchParams): LibraryFilters => {
     }
   }
   filters.createdAfter = searchParams.get(CREATED_AFTER_PARAM) ?? undefined;
-  filters.updatedAfter = searchParams.get(UPDATED_AFTER_PARAM) ?? undefined;
   return filters;
 };
 
@@ -67,9 +65,6 @@ export const serializeFilters = (filters: LibraryFilters): URLSearchParams => {
   if (filters.createdAfter) {
     entries.push([CREATED_AFTER_PARAM, filters.createdAfter]);
   }
-  if (filters.updatedAfter) {
-    entries.push([UPDATED_AFTER_PARAM, filters.updatedAfter]);
-  }
 
   const searchParams = new URLSearchParams();
   entries.sort(([a], [b]) => a.localeCompare(b)).forEach(([key, value]) => {
@@ -84,7 +79,7 @@ export type LibraryFilterActions = {
   toggleFacetValue: (key: FacetKey, value: string) => void;
   removeFacetValue: (key: FacetKey, value: string) => void;
   setRange: (key: RangeKey, range: Range | undefined) => void;
-  setDate: (key: "createdAfter" | "updatedAfter", value: string | undefined) => void;
+  setDate: (key: "createdAfter", value: string | undefined) => void;
   clearAll: () => void;
 };
 
@@ -193,7 +188,7 @@ export const useLibraryFilters = (): UseLibraryFilters => {
   );
 
   const setDate = useCallback(
-    (key: "createdAfter" | "updatedAfter", value: string | undefined) => {
+    (key: "createdAfter", value: string | undefined) => {
       update((draft) => {
         draft[key] = value || undefined;
       });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,6 +71,10 @@ const router = createBrowserRouter([
         lazy: lazyRoute(() => import("./components/statistics/TopDeviceTypes"), "TopDeviceTypes"),
       },
       {
+        path: "/whats-new",
+        lazy: lazyRoute(() => import("./components/statistics/WhatsNew"), "WhatsNew"),
+      },
+      {
         path: "/statistics/weekly-contributions",
         lazy: lazyRoute(() => import("./components/statistics/WeeklyContributions"), "WeeklyContributions"),
       },

--- a/src/types/ColorMode.tsx
+++ b/src/types/ColorMode.tsx
@@ -3,5 +3,4 @@ export enum ColorMode {
   COLOR_TEMP = "color_temp",
   BRIGHTNESS = "brightness",
   EFFECT = "effect",
-  TAPERING = "tapering",
 }

--- a/src/types/LibraryFilters.ts
+++ b/src/types/LibraryFilters.ts
@@ -26,14 +26,12 @@ export type LibraryFilters = {
   search: string;
   facets: Record<FacetKey, string[]>;
   ranges: Partial<Record<RangeKey, Range>>;
-  /** ISO date strings (yyyy-mm-dd), inclusive lower bounds. */
+  /** ISO date string (yyyy-mm-dd), inclusive lower bound. */
   createdAfter?: string;
-  updatedAfter?: string;
 };
 
 export const SEARCH_PARAM = "q";
 export const CREATED_AFTER_PARAM = "createdAfter";
-export const UPDATED_AFTER_PARAM = "updatedAfter";
 
 export const FACET_LABELS: Record<FacetKey, string> = {
   deviceType: "Device type",
@@ -77,6 +75,5 @@ export const countActiveFilters = (filters: LibraryFilters): number => {
   }
   count += Object.keys(filters.ranges).length;
   if (filters.createdAfter) count += 1;
-  if (filters.updatedAfter) count += 1;
   return count;
 };

--- a/src/types/PowerProfile.tsx
+++ b/src/types/PowerProfile.tsx
@@ -34,6 +34,13 @@ export type PowerProfile = {
   subProfileCount: number;
   minVersion?: string | null;
   compatibleIntegrations: string[];
+  measureSettings?: Record<string, unknown> | null;
+  measureDeviceFirmware?: string | null;
+  /** Set when Powercalc can discover this model automatically, by "device" or by "entity". */
+  discoveryBy?: string | null;
+  onlySelfUsage?: boolean;
+  /** "<manufacturer>/<model>" of the profile this one reuses measurements from. */
+  linkedProfile?: string | null;
   usageStats: UsageStats;
 };
 

--- a/src/utils/libraryFiltering.test.ts
+++ b/src/utils/libraryFiltering.test.ts
@@ -158,12 +158,6 @@ describe("applyFilters", () => {
     expect(modelIds(result)).toEqual(["LED1836G9"]);
   });
 
-  it("excludes profiles that were never updated when filtering on updated-after", () => {
-    const result = applyFilters(profiles, withFilters({ updatedAfter: "2025-01-01" }));
-
-    expect(modelIds(result)).toEqual(["LCA001"]);
-  });
-
   it("combines search with facets", () => {
     const result = applyFilters(
       profiles,

--- a/src/utils/libraryFiltering.ts
+++ b/src/utils/libraryFiltering.ts
@@ -138,9 +138,6 @@ export const applyFiltersExcept = (
     if (filters.createdAfter && !matchesDate(profile.createdAt, filters.createdAfter)) {
       return false;
     }
-    if (filters.updatedAfter && !matchesDate(profile.updatedAt, filters.updatedAfter)) {
-      return false;
-    }
     return true;
   });
 

--- a/src/utils/profileMappers.ts
+++ b/src/utils/profileMappers.ts
@@ -36,6 +36,11 @@ export const mapToBasePowerProfile = (
     subProfileCount: model.sub_profile_count || 0,
     minVersion: model.min_version || null,
     compatibleIntegrations: model.compatible_integrations || [],
+    measureSettings: model.measure_settings ?? null,
+    measureDeviceFirmware: model.measure_device_firmware ?? null,
+    discoveryBy: model.discovery_by ?? null,
+    onlySelfUsage: model.only_self_usage ?? false,
+    linkedProfile: model.linked_profile ?? null,
     usageStats: usageStats
   };
 }

--- a/src/utils/recency.test.ts
+++ b/src/utils/recency.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { ColorMode } from "../types/ColorMode";
+import { DeviceType } from "../types/DeviceType";
+import type { PowerProfile } from "../types/PowerProfile";
+
+import { isRecentlyAdded, recentlyAdded } from "./recency";
+
+const NOW = new Date("2026-08-08T00:00:00Z");
+
+const createProfile = (createdAt: string, modelId = "M1"): PowerProfile => ({
+  manufacturer: { dirName: "signify", fullName: "Signify" },
+  modelId,
+  name: "A light",
+  aliases: [],
+  deviceType: DeviceType.LIGHT,
+  colorModes: [ColorMode.BRIGHTNESS],
+  updatedAt: new Date("2026-08-01T00:00:00Z"),
+  createdAt: new Date(createdAt),
+  description: "",
+  measureDevice: "Shelly Plug S",
+  measureMethod: "script",
+  measureDescription: "",
+  calculationStrategy: "lut",
+  standbyPower: 0.4,
+  maxPower: 9,
+  author: { name: "Bram", githubUsername: "bramstroker" },
+  subProfileCount: 0,
+  minVersion: null,
+  compatibleIntegrations: [],
+  usageStats: { installationCount: 1, deviceCount: 1, percentage: 0.1 },
+});
+
+describe("isRecentlyAdded", () => {
+  it("flags a profile added inside the window", () => {
+    expect(isRecentlyAdded(createProfile("2026-07-20T00:00:00Z"), NOW)).toBe(true);
+  });
+
+  it("does not flag one added before the window", () => {
+    expect(isRecentlyAdded(createProfile("2026-05-01T00:00:00Z"), NOW)).toBe(false);
+  });
+
+  it("ignores updatedAt entirely", () => {
+    // Nearly every profile has a recent updatedAt from bulk re-imports, so it must not count.
+    const old = createProfile("2024-01-01T00:00:00Z");
+    old.updatedAt = NOW;
+
+    expect(isRecentlyAdded(old, NOW)).toBe(false);
+  });
+
+  it("does not flag a future creation date", () => {
+    expect(isRecentlyAdded(createProfile("2026-09-01T00:00:00Z"), NOW)).toBe(false);
+  });
+});
+
+describe("recentlyAdded", () => {
+  it("returns matches newest first", () => {
+    const profiles = [
+      createProfile("2026-07-01T00:00:00Z", "just-outside"),
+      createProfile("2026-08-05T00:00:00Z", "newest"),
+      createProfile("2020-01-01T00:00:00Z", "ancient"),
+      createProfile("2026-07-25T00:00:00Z", "middle"),
+    ];
+
+    // "just-outside" is 38 days old, so the 30-day window excludes it.
+    expect(recentlyAdded(profiles, 30, NOW).map((p) => p.modelId)).toEqual(["newest", "middle"]);
+
+    expect(recentlyAdded(profiles, 90, NOW).map((p) => p.modelId)).toEqual([
+      "newest",
+      "middle",
+      "just-outside",
+    ]);
+  });
+});

--- a/src/utils/recency.ts
+++ b/src/utils/recency.ts
@@ -1,0 +1,38 @@
+import type { PowerProfile } from "../types/PowerProfile";
+
+/**
+ * How recently a profile has to have been added to count as new. Roughly 8 profiles land in a
+ * month, so this keeps the badge meaningful rather than decorative.
+ *
+ * Note this deliberately uses `createdAt`, not `updatedAt`: nearly every profile in the library
+ * carries a recent `updated_at` from bulk re-imports, so it says nothing about actual change.
+ */
+export const NEW_PROFILE_DAYS = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const daysSince = (date: Date | null | undefined, now: Date = new Date()): number | null => {
+  if (!date || Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return (now.getTime() - date.getTime()) / DAY_MS;
+};
+
+export const isRecentlyAdded = (
+  profile: PowerProfile,
+  now: Date = new Date(),
+  withinDays: number = NEW_PROFILE_DAYS,
+): boolean => {
+  const age = daysSince(profile.createdAt, now);
+  return age !== null && age >= 0 && age <= withinDays;
+};
+
+/** Newest first. */
+export const recentlyAdded = (
+  profiles: PowerProfile[],
+  withinDays: number = NEW_PROFILE_DAYS,
+  now: Date = new Date(),
+): PowerProfile[] =>
+  profiles
+    .filter((profile) => isRecentlyAdded(profile, now, withinDays))
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());


### PR DESCRIPTION
Follows on from #229. Four commits: two on mobile layout, two adding features to the profile page and library.

## Mobile

The grid needed a 770px-wide table inside a 390px viewport, and header plus footer ate 35% of the screen.

- Results render as a card list below `md` — device-type icon, `Manufacturer · Model`, name, aliases. No horizontal scrolling.
- Header drops the letter-spaced wordmark below `md` so search fits inline: 152px → 64px.
- The footer no longer stays pinned on phones; the pinned app-shell is desktop only.
- The `/` shortcut hint is hidden without a keyboard.

Measured at 390×844: visible profiles went from ~7 with two columns cut off, to 10 complete.

## Profile page

- **"Use this profile" card.** Leads with the My Home Assistant config-flow button, since the docs recommend the GUI over YAML, with a sub-profile-aware YAML snippet collapsible underneath.
- **Fields the API publishes but the UI hid** are now shown: `measure_settings` (on 530 of 728 profiles), `measure_device_firmware`, `discovery_by`, `only_self_usage`, and `linked_profile` as a link to the profile it points at.
- **Headline tiles** under the title for device type, max power, standby and sub profiles, each with the device's own icon from the map the grid and filter panel already share.
- **Attributes grouped** into Device, Power, Measurement and Library. Items flow left to right within a section, so the round-robin dealer and its breakpoint-dependent column count are gone.
- Spacing fix: the Insights card and the setup card were flush against each other.

## Library

- Profiles added in the last 30 days carry a **New** badge, and `/whats-new` lists the last 90 days grouped by day.
- **Dropped the "Updated after" filter.** 717 of 728 profiles carry an `updated_at` from the last 90 days, so it barely discriminated. Recency keys off `created_at` throughout.
- Removed the `tapering` colour mode, corrected upstream in the library. No filter change was needed — facet options are derived from the data, so it disappeared on its own.

## Verification

`type-check`, `lint`, 75 unit tests and 31 e2e tests pass, the latter with `--workers=1` to match CI.

New coverage worth noting: `recency.test.ts` asserts a recent `updatedAt` does **not** make a profile "new", which is the trap the data would otherwise set, and `ProfileSetup.test.ts` pins the YAML format including the `model: LIFX Z/length_9` sub-profile form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)